### PR TITLE
Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ path = "./src/lib.rs"
 
 [dependencies]
 chrono = "0.3"
-cookie = { version = "0.6", features = [ "percent-encode" ] }
+cookie = { version = "0.8", features = [ "percent-encode" ] }
 csrf = { version = "0.1", features = [ "iron" ] }
 hyper = "0.10"
 iron = "0.5"
 log = "0.3"
-ring = "0.7"
+ring = "0.9.4"
 rust-crypto = "0.2"
 rustc-serialize = "0.3"
 urlencoded = "0.5"


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another dependend on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.

Note that this requires cookie-rs 0.8.0 to be released, because the previous version of cookie-rs depended on *ring* 0.7.6, which would cause exactly the kind of multi-linking problem that this is trying to (in the end) prevent. See https://github.com/alexcrichton/cookie-rs/pull/89.